### PR TITLE
Fix utils path in Dockerfiles

### DIFF
--- a/docker/Dockerfile.processor
+++ b/docker/Dockerfile.processor
@@ -21,7 +21,7 @@ RUN pip install --no-warn-script-location -r requirements.txt
 
 # Copy sources and libraries
 COPY --chown=susit ./processor /susit/processor
-COPY --chown=susit ../utils /susit/processor/utils
+COPY --chown=susit ./utils /susit/processor/utils
 
 # Run as non-root user
 CMD [ "python", "processor.py" ]

--- a/docker/Dockerfile.scheduler
+++ b/docker/Dockerfile.scheduler
@@ -21,7 +21,7 @@ RUN pip install --no-warn-script-location -r requirements.txt
 
 # Copy sources and libraries
 COPY --chown=susit ./scheduler /susit/scheduler
-COPY --chown=susit ../utils /susit/scheduler/utils
+COPY --chown=susit ./utils /susit/scheduler/utils
 
 # Run as non-root user
 CMD [ "python", "scheduler.py" ]


### PR DESCRIPTION
Use the correct path ./utils processor and scheduler Dockerfiles.

## Description

Trying to get everything up and running fails when building process and scheduler
containers due to a path error.

$ docker-compose up -d

Creating network "sustainability-insights-in-a-box_default" with the default driver
Building processor
Sending build context to Docker daemon  2.216MB
Step 1/10 : FROM python:3.11-slim
 ---> 0243f46bb8c2
Step 2/10 : RUN apt update -y     && apt upgrade -y     && apt install -y ssh     && pip install --upgrade pip
 ---> Using cache
 ---> 83ee0049cefe
Step 3/10 : RUN adduser --quiet --system --group --shell /usr/bin/bash --home /susit susit
 ---> Using cache
 ---> 893caa5c5019
Step 4/10 : USER susit
 ---> Using cache
 ---> c36659a9694a
Step 5/10 : WORKDIR /susit/processor
 ---> Using cache
 ---> 25e98bb20286
Step 6/10 : COPY --chown=susit ./processor/requirements.txt /susit/processor/requirements.txt
 ---> Using cache
 ---> 7e81a230b283
Step 7/10 : RUN pip install --no-warn-script-location -r requirements.txt
 ---> Using cache
 ---> 74f5eae942e8
Step 8/10 : COPY --chown=susit ./processor /susit/processor
 ---> Using cache
 ---> 6325bd1279a5
Step 9/10 : COPY --chown=susit ../utils /susit/processor/utils
COPY failed: forbidden path outside the build context: ../utils ()
ERROR: Service 'processor' failed to build : Build failed

(...)

Building scheduler
Sending build context to Docker daemon  2.216MB
Step 1/10 : FROM python:3.11-slim
 ---> 0243f46bb8c2
Step 2/10 : RUN apt update -y     && apt upgrade -y     && apt install -y ssh     && pip install --upgrade pip
 ---> Using cache
 ---> 83ee0049cefe
Step 3/10 : RUN adduser --quiet --system --group --shell /usr/bin/bash --home /susit susit
 ---> Using cache
 ---> 893caa5c5019
Step 4/10 : USER susit
 ---> Using cache
 ---> c36659a9694a
Step 5/10 : WORKDIR /susit/scheduler
 ---> Running in b6409e485684
Removing intermediate container b6409e485684
 ---> 17b9c0ca21f3
Step 6/10 : COPY --chown=susit ./scheduler/requirements.txt /susit/scheduler//requirements.txt
 ---> 0fb8ec99d12d
Step 7/10 : RUN pip install --no-warn-script-location -r requirements.txt
 ---> Running in 59a63f6760d4
Defaulting to user installation because normal site-packages is not writeable
Collecting confluent_kafka==2.2.0 (from -r requirements.txt (line 1))
  Downloading confluent_kafka-2.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.4 kB)
Collecting cryptography==41.0.1 (from -r requirements.txt (line 2))
  Downloading cryptography-41.0.1-cp37-abi3-manylinux_2_28_x86_64.whl.metadata (5.2 kB)
Collecting jsonschema==4.18.4 (from -r requirements.txt (line 3))
  Downloading jsonschema-4.18.4-py3-none-any.whl.metadata (7.8 kB)
Collecting ruamel.yaml==0.17.32 (from -r requirements.txt (line 4))
  Downloading ruamel.yaml-0.17.32-py3-none-any.whl.metadata (17 kB)
Collecting schedule==1.2.0 (from -r requirements.txt (line 5))
  Downloading schedule-1.2.0-py2.py3-none-any.whl.metadata (3.3 kB)
Collecting python-dateutil==2.8.2 (from -r requirements.txt (line 6))
  Downloading python_dateutil-2.8.2-py2.py3-none-any.whl.metadata (8.2 kB)
Collecting cffi>=1.12 (from cryptography==41.0.1->-r requirements.txt (line 2))
  Downloading cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.5 kB)
Collecting attrs>=22.2.0 (from jsonschema==4.18.4->-r requirements.txt (line 3))
  Downloading attrs-23.2.0-py3-none-any.whl.metadata (9.5 kB)
Collecting jsonschema-specifications>=2023.03.6 (from jsonschema==4.18.4->-r requirements.txt (line 3))
  Downloading jsonschema_specifications-2023.12.1-py3-none-any.whl.metadata (3.0 kB)
Collecting referencing>=0.28.4 (from jsonschema==4.18.4->-r requirements.txt (line 3))
  Downloading referencing-0.35.1-py3-none-any.whl.metadata (2.8 kB)
Collecting rpds-py>=0.7.1 (from jsonschema==4.18.4->-r requirements.txt (line 3))
  Downloading rpds_py-0.19.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.1 kB)
Collecting ruamel.yaml.clib>=0.2.7 (from ruamel.yaml==0.17.32->-r requirements.txt (line 4))
  Downloading ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl.metadata (2.2 kB)
Collecting six>=1.5 (from python-dateutil==2.8.2->-r requirements.txt (line 6))
  Downloading six-1.16.0-py2.py3-none-any.whl.metadata (1.8 kB)
Collecting pycparser (from cffi>=1.12->cryptography==41.0.1->-r requirements.txt (line 2))
  Downloading pycparser-2.22-py3-none-any.whl.metadata (943 bytes)
Downloading confluent_kafka-2.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (4.0 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.0/4.0 MB 4.5 MB/s eta 0:00:00
Downloading cryptography-41.0.1-cp37-abi3-manylinux_2_28_x86_64.whl (4.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.3/4.3 MB 6.7 MB/s eta 0:00:00
Downloading jsonschema-4.18.4-py3-none-any.whl (80 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 81.0/81.0 kB 3.7 MB/s eta 0:00:00
Downloading ruamel.yaml-0.17.32-py3-none-any.whl (112 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 112.2/112.2 kB 5.7 MB/s eta 0:00:00
Downloading schedule-1.2.0-py2.py3-none-any.whl (11 kB)
Downloading python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 247.7/247.7 kB 8.5 MB/s eta 0:00:00
Downloading attrs-23.2.0-py3-none-any.whl (60 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 60.8/60.8 kB 3.1 MB/s eta 0:00:00
Downloading cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (464 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 464.8/464.8 kB 5.8 MB/s eta 0:00:00
Downloading jsonschema_specifications-2023.12.1-py3-none-any.whl (18 kB)
Downloading referencing-0.35.1-py3-none-any.whl (26 kB)
Downloading rpds_py-0.19.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (355 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 355.8/355.8 kB 7.9 MB/s eta 0:00:00
Downloading ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl (544 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 544.0/544.0 kB 8.9 MB/s eta 0:00:00
Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
Downloading pycparser-2.22-py3-none-any.whl (117 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 117.6/117.6 kB 6.3 MB/s eta 0:00:00
Installing collected packages: confluent_kafka, six, schedule, ruamel.yaml.clib, rpds-py, pycparser, attrs, ruamel.yaml, referencing, python-dateutil, cffi, jsonschema-specifications, cryptography, jsonschema
Successfully installed attrs-23.2.0 cffi-1.16.0 confluent_kafka-2.2.0 cryptography-41.0.1 jsonschema-4.18.4 jsonschema-specifications-2023.12.1 pycparser-2.22 python-dateutil-2.8.2 referencing-0.35.1 rpds-py-0.19.0 ruamel.yaml-0.17.32 ruamel.yaml.clib-0.2.8 schedule-1.2.0 six-1.16.0
Removing intermediate container 59a63f6760d4
 ---> 7eb680164a9d
Step 8/10 : COPY --chown=susit ./scheduler /susit/scheduler
 ---> 146e1a911778
Step 9/10 : COPY --chown=susit ../utils /susit/scheduler/utils
COPY failed: forbidden path outside the build context: ../utils ()
ERROR: Service 'scheduler' failed to build : Build failed


## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
